### PR TITLE
 comment these two from here as host override to replace invalid inhe…

### DIFF
--- a/ansible/inventory/host_vars/gs-02.yml
+++ b/ansible/inventory/host_vars/gs-02.yml
@@ -20,9 +20,8 @@ host_services:
 
   # Raw Nix list expression.
   # A normal YAML list currently generates invalid Nix single quotes.
-  luxnix.ollama.models: '[ "gemma4:e2b" ]'
-
-  ollama.host: '"0.0.0.0"'
+  # luxnix.ollama.models: '[ "gemma4:e2b" ]'
+  # ollama.host: '"0.0.0.0"'
 
   # GLM service
   luxnix.glm52.enable: "true"


### PR DESCRIPTION
The shared GPU configuration (ansible/inventory/group_vars/gpu_server.yml) defines default Ollama settings for all GPU servers. ansible/inventory/host_vars/gs-02.yml provides host-specific overrides. The inherited values were malformed for Nix (single-quoted list syntax), causing the Nix build to fail with a syntax error, so the host-level entries were removed/overridden to allow gs-02 to use valid configuration while leaving the shared GPU defaults unchanged.